### PR TITLE
Fix cljs.storm.utils to not include clojure.java.io in :cljs

### DIFF
--- a/src/main/clojure/cljs/storm/utils.cljc
+++ b/src/main/clojure/cljs/storm/utils.cljc
@@ -1,6 +1,6 @@
 (ns cljs.storm.utils
-  (:require [clojure.string :as str]
-            [clojure.java.io :as io])
+  (:require [clojure.string :as str])
+  #?(:clj (:require [clojure.java.io :as io]))
   #?(:clj (:import [java.nio.file Files]
                    [java.nio.file.attribute FileTime])))
 


### PR DESCRIPTION
Version 1.11.60-4, running into the following error when following cljs quickstart.
```
[:main] Build failure:
The required namespace "clojure.java.io" is not available, it was required by "cljs/storm/utils.cljc".
"clojure/java/io.clj" was found on the classpath. Maybe this library only supports CLJ?
```